### PR TITLE
Use .get() on REQUEST_ID_UNIQUE_VALUE_PREFIX

### DIFF
--- a/flask_request_id_header/middleware/__init__.py
+++ b/flask_request_id_header/middleware/__init__.py
@@ -34,7 +34,7 @@ class RequestID(object):
         :param app: Flask application
         """
         self.app = app.wsgi_app
-        self._unique_request_id_value_prefix = app.config['REQUEST_ID_UNIQUE_VALUE_PREFIX']
+        self._unique_request_id_value_prefix = app.config.get('REQUEST_ID_UNIQUE_VALUE_PREFIX')
         self._header_name = "X-Request-ID"
         self._flask_header_name = f"HTTP_{ self._header_name.upper().replace('-', '_') }"
 


### PR DESCRIPTION
Direct access to the Flask config when no `REQUEST_ID_UNIQUE_VALUE_PREFIX` is explicitly set generates a KeyError. Without this pull request you need to do `app.config['REQUEST_ID_UNIQUE_VALUE_PREFIX'] = None` in order to make the middleware work

```
...
  File "/usr/src/app/SON/frontend/views.py", line 156, in <module>
    RequestID(app)
  File "/opt/venv/lib/python3.7/site-packages/flask_request_id_header/middleware/__init__.py", line 37, in __init__
    self._unique_request_id_value_prefix = app.config['REQUEST_ID_UNIQUE_VALUE_PREFIX']
KeyError: 'REQUEST_ID_UNIQUE_VALUE_PREFIX'
```